### PR TITLE
fix: correct audience cask dmg url to aarch64 build

### DIFF
--- a/Casks/audience.rb
+++ b/Casks/audience.rb
@@ -2,7 +2,7 @@ cask "audience" do
   version "1.3.0"
   sha256 "bc037d3335c2c9c2d91850b1a1eebc554323a8228e4ed8d6278bf072d591ab70"
 
-  url "https://github.com/statik/audience/releases/download/v#{version}/Audience_#{version}_universal.dmg"
+  url "https://github.com/statik/audience/releases/download/v#{version}/Audience_#{version}_aarch64.dmg"
   name "Audience"
   desc "PTZ camera controller with live video feed and preset management"
   homepage "https://github.com/statik/audience"


### PR DESCRIPTION
## Problem

`brew upgrade audience` 404s on v1.3.0. The cask url points at `Audience_1.3.0_universal.dmg`, but the release only published `Audience_1.3.0_aarch64.dmg`.

## Cause

statik/audience PR #16 switched the macOS release build target from `universal-apple-darwin` to `aarch64-apple-darwin`, renaming the dmg asset. The cask url template was not updated to match. v1.2.0 (last universal build) still installs; v1.3.0 is the first broken release.

## Fix

One-word change to the url filename: `_universal.dmg` -> `_aarch64.dmg`. The pinned `sha256` already matches the aarch64 dmg (the generator hashes the actual downloaded asset), so it is unchanged.

Verified: `HEAD` on the corrected url returns 200; the old url returns 404.

The generator script in statik/audience (`scripts/update-package-managers.sh`) is being fixed separately so future releases produce the correct url.